### PR TITLE
Fix returned github issue url

### DIFF
--- a/issue_router/main.py
+++ b/issue_router/main.py
@@ -82,7 +82,7 @@ async def create_issue(request: CreateIssueRequest):
         )
         response.raise_for_status()
         response_json = response.json()
-        url = response_json['url']
+        url = response_json['html_url']
     except Exception as e:
         raise HTTPException(status_code=422, detail=str(e))
 


### PR DESCRIPTION
`url` is a link to the api response, whereas `html_url` is a link to the actual issue on github.